### PR TITLE
Component workflow added: Claude Security Review

### DIFF
--- a/.github/workflows/component-claude-security-review.yml
+++ b/.github/workflows/component-claude-security-review.yml
@@ -1,0 +1,53 @@
+name: "Component workflow: Claude Security Review"
+
+on:
+  workflow_call:
+    inputs:
+      context_hint:
+        description: "Optional repo-specific guidance appended to the security review prompt"
+        required: false
+        type: string
+        default: ""
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+
+jobs:
+  claude-security-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Security Review
+        id: claude-security-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Run the `/security-review` skill on this pull request.
+
+            Focus on the diff. Read surrounding context where needed to understand
+            data flow, trust boundaries, and authorization. Use the repository's
+            CLAUDE.md for conventions.
+
+            ${{ inputs.context_hint }}
+
+            Report findings as a single PR comment. For each finding include:
+            severity, file:line, the vulnerability, and a concrete fix. If no
+            issues are found, post a brief confirmation comment.
+
+            Use `gh pr comment` with your Bash tool to leave the review.
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary
Adds \`component-claude-security-review.yml\` — reusable workflow that wraps \`anthropics/claude-code-action@v1\` to run the \`/security-review\` skill on pull requests.

Originated as a per-repo workflow in [eco_core PR #468](https://github.com/hubbado/eco_core/pull/468). Extracted here so other Hubbado repos can opt in with a thin caller workflow.

## How callers use it
\`\`\`yaml
# .github/workflows/claude-security-review.yml in caller repo
name: Claude Security Review

on:
  pull_request:
    types: [opened, synchronize]

jobs:
  security-review:
    uses: hubbado/workflows/.github/workflows/component-claude-security-review.yml@main
    secrets:
      CLAUDE_CODE_OAUTH_TOKEN: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
    with:
      context_hint: |
        # Optional repo-specific guidance for the agent
\`\`\`

Each caller repo needs:
- \`CLAUDE_CODE_OAUTH_TOKEN\` secret available to the workflow.
- The caller workflow file present on the repo's default branch (Anthropic's workflow validation requirement).

## Why a context_hint input
The original eco_core workflow contained a Trailblazer-specific hint in the prompt. Hardcoding stack details in a shared workflow doesn't generalise — \`context_hint\` lets each caller append its own guidance without forking the prompt.

## Test plan
- Merge this PR so the workflow is available at \`@main\`.
- Update eco_core's \`claude-security-review.yml\` to call this component (separate PR).
- Open a test PR in eco_core touching code — confirm the workflow runs and posts a security review comment matching prior behaviour.
- Roll out to other repos as desired.