### PR TITLE
allowed_bots input added to Claude security review component

### DIFF
--- a/.github/workflows/component-claude-security-review.yml
+++ b/.github/workflows/component-claude-security-review.yml
@@ -9,10 +9,10 @@ on:
         type: string
         default: ""
       allowed_bots:
-        description: "Comma-separated bot logins (without the [bot] suffix) permitted to trigger the review, or * for all. Empty blocks all bots."
+        description: "Comma-separated bot logins (without the [bot] suffix) permitted to trigger the review, or * for all. Set to an empty string to block all bots."
         required: false
         type: string
-        default: ""
+        default: "hubbado-automation"
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true

--- a/.github/workflows/component-claude-security-review.yml
+++ b/.github/workflows/component-claude-security-review.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: ""
+      allowed_bots:
+        description: "Comma-separated bot logins (without the [bot] suffix) permitted to trigger the review, or * for all. Empty blocks all bots."
+        required: false
+        type: string
+        default: ""
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
@@ -32,6 +37,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: ${{ inputs.allowed_bots }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

`anthropics/claude-code-action@v1` refuses to run when the triggering actor is a bot:

```
Action failed with error: Workflow initiated by non-human actor: <bot> (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

Repos whose dependency-update PRs are opened by the `hubbado-automation` GitHub App (a Bot actor) hit this on every such PR, so the security review check fails. This adds an `allowed_bots` `workflow_call` input, passed through to the action.

- **Default `hubbado-automation`** — the org-standard automation bot. Since this component is org-internal, consuming repos need no extra config to allow it.
- Override with a different bot, `*` for all bots, or `""` to block all bots.

Matching is case-insensitive and strips the `[bot]` suffix (per the action source), so `hubbado-automation` matches actor `hubbado-automation[bot]`.

### Behaviour change
The component's default posture changes: `hubbado-automation`-triggered PRs now get a security review by default (previously all bots were blocked). This permits exactly one trusted org bot; repos where it doesn't open PRs are unaffected.

## Test plan
- Merge this.
- Confirm the security review runs (instead of failing) on a hubbado_core dependency PR opened by `hubbado-automation`.
- Confirm a normal human-authored PR is unaffected.